### PR TITLE
make Microsoft.Build.Tasks.*.dll match tools version being used

### DIFF
--- a/src/ls.pubignore.wpp.targets
+++ b/src/ls.pubignore.wpp.targets
@@ -66,7 +66,7 @@
   <UsingTask TaskName="ReadPublishIgnoreFile"
              TaskFactory="CodeTaskFactory"
              Condition=" '$(ls-DefineReadPublishIgnoreFileInline)'=='true' "
-             AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
+             AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v$(MSBuildToolsVersion).dll">
     <ParameterGroup>
       <FilePath ParameterType="System.String" Required="true"/>
 


### PR DESCRIPTION
Makes it work with Visual Studio 2013 and MSBuild shipped with it