### PR TITLE
Update to help resolve location of Microsoft.Build.Tasks.*.dll

### DIFF
--- a/src/ls.pubignore.wpp.targets
+++ b/src/ls.pubignore.wpp.targets
@@ -63,10 +63,16 @@
   <PropertyGroup>
     <ls-DefineReadPublishIgnoreFileInline Condition =" '$(ls-DefineReadPublishIgnoreFileInline)' == '' ">true</ls-DefineReadPublishIgnoreFileInline>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(ls-msbuildtasks-path)'=='' ">
+    <ls-msbuildtasks-path>$(MSBuildToolsPath)\Microsoft.Build.Tasks.v$(MSBuildToolsVersion).dll</ls-msbuildtasks-path>
+    <ls-msbuildtasks-path Condition=" !Exists('$(ls-msbuildtasks-path)')">$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll</ls-msbuildtasks-path>
+    <ls-msbuildtasks-path Condition=" !Exists('$(ls-msbuildtasks-path)')">$(MSBuildFrameworkToolsPath)\Microsoft.Build.Tasks.v4.0.dll</ls-msbuildtasks-path>
+    <ls-msbuildtasks-path Condition=" !Exists('$(ls-msbuildtasks-path)')">$(windir)\Microsoft.NET\Framework\v4.0.30319\Microsoft.Build.Tasks.v4.0.dll</ls-msbuildtasks-path>
+  </PropertyGroup>
   <UsingTask TaskName="ReadPublishIgnoreFile"
              TaskFactory="CodeTaskFactory"
              Condition=" '$(ls-DefineReadPublishIgnoreFileInline)'=='true' "
-             AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v$(MSBuildToolsVersion).dll">
+             AssemblyFile="$(ls-msbuildtasks-path)">
     <ParameterGroup>
       <FilePath ParameterType="System.String" Required="true"/>
 


### PR DESCRIPTION
Update to resolve https://github.com/ligershark/publish-ignore/issues/12.

Tested on VS 2015 RTM, with no other version installed. 
